### PR TITLE
try using mypy with some cross-compatibility code

### DIFF
--- a/compatibility.py
+++ b/compatibility.py
@@ -1,0 +1,19 @@
+from typing import Protocol, Union
+
+class DjangoGEOSGeometry(Protocol):
+    valid: bool
+
+class ShapelyGeometry(Protocol):
+    is_valid: bool
+
+def check_validity(geometry: Union[DjangoGEOSGeometry, ShapelyGeometry]) -> bool:
+    """
+    Checks if the geometry is valid, in a way that is cross-compatible between
+    shapely and django.
+    """
+    try:
+        # geometry is a DjangoGEOSGeometry
+        return geometry.valid
+    except AttributeError:
+        # geometry is a ShapelyGeometry
+        return geometry.is_valid


### PR DESCRIPTION
I have some code that takes either a GEOSGeometry or a shapely shape. I do this because I want to have flexible build options. I don't want my django code to _have to_ install shapely, but I also don't want my shapely code to have to install django. These two geometry implementations have _slightly_ different interfaces, though, so I want some wrapper code for compatibility. I have an attempt at doing so, here, but I can't figure out how to adjust this to pass mypy. 

```
(kapi) teddyward@teddys-mbp funwithmypy % mypy compatibility.py 
compatibility.py:16: error: Item "ShapelyGeometry" of "Union[DjangoGEOSGeometry, ShapelyGeometry]" has no attribute "valid"
compatibility.py:19: error: Item "DjangoGEOSGeometry" of "Union[DjangoGEOSGeometry, ShapelyGeometry]" has no attribute "is_valid"
Found 2 errors in 1 file (checked 1 source file)
```


Any suggestions?